### PR TITLE
Fix build failures caused by rclc macro name change

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -28,3 +28,5 @@ eProsima
 Robert Bosch GmbH
     Ralph Lange <ralph.lange@de.bosch.com>
     Raphael Vogelgsang <Raphael.Vogelgsang@de.bosch.com>
+
+Robert Wilbrandt <robert@stamm-wilbrandt.de>

--- a/apps/int32_publisher/app.c
+++ b/apps/int32_publisher/app.c
@@ -21,7 +21,7 @@ std_msgs__msg__Int32 msg;
 
 void timer_callback(rcl_timer_t * timer, int64_t last_call_time)
 {
-	UNUSED(last_call_time);
+	RCLC_UNUSED(last_call_time);
 	if (timer != NULL) {
 		RCSOFTCHECK(rcl_publish(&publisher, &msg, NULL));
 		msg.data++;

--- a/apps/ping_pong/app.c
+++ b/apps/ping_pong/app.c
@@ -34,7 +34,7 @@ int pong_count;
 
 void ping_timer_callback(rcl_timer_t * timer, int64_t last_call_time)
 {
-	UNUSED(last_call_time);
+	RCLC_UNUSED(last_call_time);
 
 	if (timer != NULL) {
 


### PR DESCRIPTION
micro-ROS/rclc@8ae07472d727b5517a43b03418d9178519c759e0 changed the name
of the UNUSED macro to RCLC_UNUSED. This broke the build for two
examples.

Signed-off-by: Robert Wilbrandt <robert@stamm-wilbrandt.de>