### PR TITLE
Added missing header files

### DIFF
--- a/apps/int32_subscriber/app.c
+++ b/apps/int32_subscriber/app.c
@@ -2,10 +2,16 @@
 #include <rcl/error_handling.h>
 #include <rclc/rclc.h>
 #include <rclc/executor.h>
+#include <unistd.h>
 
 #include <std_msgs/msg/int32.h>
 
 #include <stdio.h>
+
+#ifdef ESP_PLATFORM
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#endif
 
 #define RCCHECK(fn) { rcl_ret_t temp_rc = fn; if((temp_rc != RCL_RET_OK)){printf("Failed status on line %d: %d. Aborting.\n",__LINE__,(int)temp_rc);vTaskDelete(NULL);}}
 #define RCSOFTCHECK(fn) { rcl_ret_t temp_rc = fn; if((temp_rc != RCL_RET_OK)){printf("Failed status on line %d: %d. Continuing.\n",__LINE__,(int)temp_rc);}}


### PR DESCRIPTION
error: implicit declaration of function 'vTaskDelete' [-Werror=implicit-function-declaration] error: implicit declaration of function 'usleep'; did you mean 'fseek'? [-Werror=implicit-function-declaration] usleep(100000);

To resolve these errors header files were added
 
#ifdef ESP_PLATFORM
#include "freertos/FreeRTOS.h"
#include "freertos/task.h"
#endif

#include <unistd.h>